### PR TITLE
Do not shade module-info.class from asm-all

### DIFF
--- a/external/asm-all/pom.xml
+++ b/external/asm-all/pom.xml
@@ -90,6 +90,14 @@
                                     </manifestEntries>
                                 </transformer>
                             </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Otherwise it gets corrupted and other tools cannot handle it properly
(see for example https://youtrack.jetbrains.com/issue/KT-23025).

Also, here's the output of `javap` on the transformed `module-info.class` file:
```
Classfile /Users/udalov/hk2/external/asm-all/module-info.class
  Last modified Apr 18, 2018; size 90 bytes
  MD5 checksum e5c89b529cf24511d1d0cb836c8bc178
Error: invalid index #4
Error: invalid index #5
open module ???@???
  minor version: 0
  major version: 53
  flags: (0x8000) ACC_MODULE
  this_class: #2                          // "module-info"
  super_class: #0
  interfaces: 0, fields: 0, methods: 0, attributes: 1
Constant pool:
  #1 = Utf8               module-info
  #2 = Class              #1              // "module-info"
  #3 = Utf8               Module
{
}
Module:
Error: invalid index #4
  #4,20                                   // ??? ACC_OPEN
Error: invalid index #5
  #5                                      // ???
  1                                       // requires
Error: invalid index #7
    #7,8000                                 // ??? ACC_MANDATED
    #0
  2                                       // exports
Error: invalid index #9
    #9,0                                    // ???
Error: invalid index #11
    #11,0                                   // ???
  0                                       // opens
  0                                       // uses
  0                                       // provides
```
As you see, there are lots of errors which means that the file is corrupted by the maven-shade-plugin.
